### PR TITLE
Fix ARM64 compatibility by replacing MonoMod hook with TSAPI hook

### DIFF
--- a/Crossplay/CrossplayPlugin.cs
+++ b/Crossplay/CrossplayPlugin.cs
@@ -68,7 +68,7 @@ namespace Crossplay
                 throw new NotSupportedException("The provided version of this plugin is outdated and will not function properly. Check for any updates here: https://github.com/Nayetdet/TerrariaCrossplay");
             }
 
-            On.Terraria.Net.NetManager.SendToClient += NetModuleHandler.OnSendToClient;
+            ServerApi.Hooks.NetSendNetData.Register(this, NetModuleHandler.OnSendNetData);
 
             ServerApi.Hooks.GameInitialize.Register(this, OnInitialize);
             ServerApi.Hooks.GamePostInitialize.Register(this, OnPostInitialize);
@@ -99,7 +99,7 @@ namespace Crossplay
         {
             if (disposing)
             {
-                On.Terraria.Net.NetManager.SendToClient -= NetModuleHandler.OnSendToClient;
+                ServerApi.Hooks.NetSendNetData.Deregister(this, NetModuleHandler.OnSendNetData);
 
                 ServerApi.Hooks.GameInitialize.Deregister(this, OnInitialize);
                 ServerApi.Hooks.GamePostInitialize.Deregister(this, OnPostInitialize);

--- a/Crossplay/NetModuleHandler.cs
+++ b/Crossplay/NetModuleHandler.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Terraria;
 using Terraria.Net;
+using TerrariaApi.Server;
 
 namespace Crossplay
 {
@@ -13,17 +14,31 @@ namespace Crossplay
             { 21, (27, 25) }, // UpdateItemDrop
         };
 
-        internal static void OnSendToClient(On.Terraria.Net.NetManager.orig_SendToClient orig, NetManager self, NetPacket packet, int playerId)
+        internal static void OnSendNetData(SendNetDataEventArgs args)
         {
-            if (playerId < 0 || playerId >= Main.maxPlayers)
+            if (args.Handled)
             {
                 return;
             }
 
-            RemoteClient client = Netplay.Clients[playerId];
-            if (client.IsConnected() && !InvalidNetPacket(packet, playerId))
+            int playerId = -1;
+            for (int i = 0; i < Main.maxPlayers; i++)
             {
-                orig(self, packet, playerId);
+                if (Netplay.Clients[i].Socket == args.socket)
+                {
+                    playerId = i;
+                    break;
+                }
+            }
+
+            if (playerId < 0)
+            {
+                return;
+            }
+
+            if (InvalidNetPacket(args.packet, playerId))
+            {
+                args.Handled = true;
             }
         }
 


### PR DESCRIPTION
Replaces On.Terraria.Net.NetManager.SendToClient (MonoMod RuntimeDetour) with ServerApi.Hooks.NetSendNetData (built-in TSAPI hook). 

Tested successfully that it starts up without issues on ARM64 (Ampere/Docker).

Fixes https://github.com/nayetdet/TerrariaCrossplay/issues/2