### PR TITLE
Add support for Terraria 1.4.4.9 (mobile)

### DIFF
--- a/Crossplay/Crossplay.csproj
+++ b/Crossplay/Crossplay.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Version>2.4.6</Version>
   </PropertyGroup>

--- a/Crossplay/Crossplay.csproj
+++ b/Crossplay/Crossplay.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Version>2.4.6</Version>
   </PropertyGroup>

--- a/Crossplay/CrossplayPlugin.cs
+++ b/Crossplay/CrossplayPlugin.cs
@@ -19,6 +19,7 @@ namespace Crossplay
     {
         private readonly Dictionary<int, string> _supportedVersions = new()
         {
+            { 279, "v1.4.4.9" },
             { 313, "v1.4.5.0" },
             { 314, "v1.4.5.1" },
             { 315, "v1.4.5.2" },
@@ -46,6 +47,7 @@ namespace Crossplay
 
         public readonly Dictionary<int, int> MaxItems = new()
         {
+            { 279, 5045 },
             { 313, 6145 },
             { 314, 6145 },
             { 315, 6145 },

--- a/Crossplay/CrossplayPlugin.cs
+++ b/Crossplay/CrossplayPlugin.cs
@@ -166,6 +166,7 @@ namespace Crossplay
 
                             if (!int.TryParse(digits, out int versionNumber))
                             {
+                                Log($"Could not parse version number from client string: '{clientVersion}' (index {args.Msg.whoAmI})", color: ConsoleColor.Yellow);
                                 return;
                             }
                             if (versionNumber == Main.curRelease)
@@ -175,6 +176,7 @@ namespace Crossplay
                             }
                             if (!_supportedVersions.ContainsKey(versionNumber))
                             {
+                                Log($"Unsupported client version {versionNumber} (raw: '{clientVersion}') from index {args.Msg.whoAmI} — add it to _supportedVersions if this is a valid mobile version", color: ConsoleColor.Yellow);
                                 return;
                             }
                             ClientVersions[index] = versionNumber;
@@ -183,7 +185,12 @@ namespace Crossplay
                                 .SetType(1)
                                 .PackString($"Terraria{Main.curRelease}")
                                 .GetByteData();
-                            Log($"Changing version of index {args.Msg.whoAmI} from {_supportedVersions[versionNumber]} => {_supportedVersions[Main.curRelease]}", color: ConsoleColor.Green);
+
+                            string fromVersion = _supportedVersions[versionNumber];
+                            string toVersion = _supportedVersions.TryGetValue(Main.curRelease, out string serverVersionName)
+                                ? serverVersionName
+                                : $"v{Main.versionNumber} (build {Main.curRelease})";
+                            Log($"Changing version of index {args.Msg.whoAmI} from {fromVersion} => {toVersion}", color: ConsoleColor.Green);
 
                             Buffer.BlockCopy(connectRequest, 0, args.Msg.readBuffer, args.Index - 3, connectRequest.Length);
                         }

--- a/Crossplay/NetModuleHandler.cs
+++ b/Crossplay/NetModuleHandler.cs
@@ -24,7 +24,7 @@ namespace Crossplay
             int playerId = -1;
             for (int i = 0; i < Main.maxPlayers; i++)
             {
-                if (Netplay.Clients[i].Socket == args.socket)
+                if (Netplay.Clients[i]?.Socket == args.socket)
                 {
                     playerId = i;
                     break;
@@ -35,6 +35,7 @@ namespace Crossplay
             {
                 return;
             }
+
 
             if (InvalidNetPacket(args.packet, playerId))
             {

--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # What is Crossplay?
-Crossplay allows for cross-platform play between all 1.4.5+ versions, utlimately closing the gap between Terraria on mobile and PC devices. This plugin works by modifying incoming packets sent from the client (and outgoing packets sent from the server) to match whatever game version the packets are being sent to. 
+Crossplay allows for cross-platform play between Terraria 1.4.4.9.x and all 1.4.5+ versions, ultimately closing the gap between Terraria on mobile and PC devices. This plugin works by modifying incoming packets sent from the client (and outgoing packets sent from the server) to match whatever game version the packets are being sent to.
+
+## Supported Versions
+- Mobile: 1.4.4.9 and all 1.4.4.9.x subversions
+- PC/Mobile: 1.4.5.0 through 1.4.5.6
 
 ## Installation
-Installation is very easy; Simply insert the plugin file (`Crossplay.dll`) into the `ServerPlugins` folder of your TShock install.
+Installation is easy; simply insert the plugin file (`Crossplay.dll`) into the `ServerPlugins` folder of your TShock install.
 
 ## Bugs & Issues
-Bugs or other issues with this plugin should be reported as an issue to this page to myself.
+Bugs or other issues with this plugin should be reported as an issue on this page.


### PR DESCRIPTION
Added protocol version 279 (Terraria 1.4.4.9) to the supported versions list.

This allows mobile players on 1.4.4.9.x to connect to TShock 1.4.5.x servers using the Crossplay plugin.

Tested on mobile version 1.4.4.9.8.